### PR TITLE
Refactor variable name for clarity

### DIFF
--- a/Devantler.K3dCLI.Tests/K3dTests/RunAsyncTests.cs
+++ b/Devantler.K3dCLI.Tests/K3dTests/RunAsyncTests.cs
@@ -15,10 +15,10 @@ public class RunAsyncTests
   public async Task RunAsync_Version_ReturnsVersion()
   {
     // Act
-    var (exitCode, message) = await K3d.RunAsync(["--version"]);
+    var (exitCode, output) = await K3d.RunAsync(["--version"]);
 
     // Assert
     Assert.Equal(0, exitCode);
-    Assert.Matches(@"^k3d version v\d+\.\d+\.\d+$", message.Split(Environment.NewLine).First().Trim());
+    Assert.Matches(@"^k3d version v\d+\.\d+\.\d+$", output.Split(Environment.NewLine).First().Trim());
   }
 }

--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ You can execute the K3d CLI commands using the `K3d` class.
 ```csharp
 using Devantler.K3dCLI;
 
-var (exitCode, message) = await K3d.RunAsync(["arg1", "arg2"]);
+var (exitCode, output) = await K3d.RunAsync(["arg1", "arg2"]);
 ```


### PR DESCRIPTION
Update the variable name from 'message' to 'output' to enhance code readability and clarity.